### PR TITLE
diagnostic.php :  Error: RosarioSIS cannot connect to the PostgreSQL …

### DIFF
--- a/diagnostic.php
+++ b/diagnostic.php
@@ -94,12 +94,17 @@ else
 	}
 	else
 	{
-		$connectstring = '';
-		if ( $DatabaseServer !== 'localhost' )
-		{
-			$connectstring .= 'host=' . $DatabaseServer . ' ';
-		}
-
+		/**
+		 * Fix pg_connect(): Unable to connect to PostgreSQL server:
+		 * could not connect to server:
+		 * No such file or directory Is the server running locally
+		 * and accepting connections on Unix domain socket "/tmp/.s.PGSQL.5432"
+		 *
+		 * Always set host, force TCP.
+		 *
+		 * @since 3.5.2
+		 */
+		$connectstring = 'host=' . $DatabaseServer . ' ';
 		if ( $DatabasePort !== '5432' )
 		{
 			$connectstring .= 'port=' . $DatabasePort .' ';


### PR DESCRIPTION
Without this patch, il get this errors message when accessing the diagnostic page "diagnostic.php"

>     Error: RosarioSIS cannot connect to the PostgreSQL database. Either Postgres is not running, it was not started with the -i option, or connections from this host are not allowed in the pg_hba.conf file. Last Postgres Error:

I found th fixe on the `database.inc.php` and i think it should be added to the `diagnostic.php` file also.